### PR TITLE
Remove allowMultipleInstances

### DIFF
--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -41,26 +41,14 @@ class GetIt {
   static GetIt get I => instance;
 
   /// You should prefer to use the `instance()` method to access an instance of [GetIt].
-  /// If you really, REALLY need more than one [GetIt] instance please set allowMultipleInstances
-  /// to true to signal you know what you are doing :-).
   factory GetIt.asNewInstance() {
-    throwIfNot(
-      allowMultipleInstances,
-      StateError(
-          'You should prefer to use the `instance()` method to access an instance of GetIt. '
-          'If you really need more than one GetIt instance please set allowMultipleInstances to true.'),
-    );
     return GetIt._();
   }
 
   /// By default it's not allowed to register a type a second time.
   /// If you really need to you can disable the asserts by setting[allowReassignment]= true
   bool allowReassignment = false;
-
-  /// By default it's not allowed to create more than one [GetIt] instance.
-  /// If you really need to you can disable the asserts by setting[allowReassignment]= true
-  static bool allowMultipleInstances = false;
-
+  
   /// retrieves or creates an instance of a registered type [T] depending on the registration function used for this type or based on a name.
   T get<T>([String instanceName]) {
     throwIfNot(

--- a/test/get_it_test.dart
+++ b/test/get_it_test.dart
@@ -105,31 +105,6 @@ void main() {
     GetIt.I.reset();
   });
 
-  test('register lazy singleton two instances of GetIt', () {
-    GetIt.allowMultipleInstances = true;
-    var secondGetIt = GetIt.asNewInstance();
-
-    constructorCounter = 0;
-    GetIt.instance.registerLazySingleton<TestBaseClass>(() => TestClass());
-    secondGetIt.registerLazySingleton<TestBaseClass>(() => TestClass());
-
-    var instance1 = GetIt.I<TestBaseClass>();
-
-    expect(instance1 is TestClass, true);
-
-    var instance2 = GetIt.I.get<TestBaseClass>();
-
-    expect(instance1, instance2);
-    expect(constructorCounter, 1);
-
-    var instanceSecondGetIt = secondGetIt.get<TestBaseClass>();
-
-    expect(instance1, isNot(instanceSecondGetIt));
-    expect(constructorCounter, 2);
-
-    GetIt.I.reset();
-  });
-
   test('trying to access not registered type', () {
     var getIt = GetIt.instance;
 


### PR DESCRIPTION
When the user calls `asNewInstance`, they are already indicating that they know what they're doing - we don't need to add an extra safety to this