### PR TITLE
Fix wrong type checking when using instanceName in combination with generic type parameter

### DIFF
--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -63,7 +63,8 @@ class GetIt {
     } else {
       final registeredObject = _factoriesByName[instanceName];
       if (registeredObject != null) {
-        if (registeredObject.registrationType is! T) {
+        if (registeredObject.instance != null &&
+            registeredObject.instance is! T) {
           print(T.toString());
           throw ArgumentError(
               "Object with name $instanceName has a different type (${registeredObject.registrationType.toString()}) than the one that is inferred (${T.toString()}) where you call it");

--- a/test/get_it_test.dart
+++ b/test/get_it_test.dart
@@ -27,6 +27,12 @@ class TestClass3 {}
 class TestClass4 {}
 
 void main() {
+
+  setUp((){
+    //make sure the instance is cleared before each test
+    GetIt.I.reset();
+  });
+
   test('register factory', () {
     var getIt = GetIt.instance;
 
@@ -319,4 +325,7 @@ void main() {
 
     expect(() => getIt('instanceName'), throwsA(TypeMatcher<ArgumentError>()));
   });
+
+  
+
 }

--- a/test/get_it_test.dart
+++ b/test/get_it_test.dart
@@ -326,6 +326,15 @@ void main() {
     expect(() => getIt('instanceName'), throwsA(TypeMatcher<ArgumentError>()));
   });
 
-  
+  test(
+      'can register a singleton with instanceName and retrieve it with generic parameters and instanceName', () {
+    final getIt = GetIt.instance;
+
+    getIt.registerSingleton(TestClass(), instanceName: 'instanceName');
+
+    var instance1 = getIt.get<TestClass>('instanceName');
+
+    expect(instance1 is TestClass, true);
+  });
 
 }


### PR DESCRIPTION
Currently, this code snippet fails:

```dart
import 'package:get_it/get_it.dart';

void main(){
  GetIt.I.registerSingleton<String>("test", instanceName: "instanceName");

  final myString = GetIt.I<String>("instanceName");

  print(myString);
}
```

with the message:

```
Unhandled exception:
Invalid argument(s): Object with name instanceName has a different type (String) than the one that is inferred (String) where you call it
#0      GetIt.get (package:get_it/get_it.dart:80:11)
#1      GetIt.call (package:get_it/get_it.dart:98:12)
#2      main (package:neocortex_mobile/get_it_test.dart:9:27)
#3      _startIsolate.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:305:19)
#4      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:172:12)
```

The reason for this is, that the logic for checking the type or the object registered with instanceName is   wrong:

```dart
 if (registeredObject.registrationType is! T) {
          print(T.toString());
          throw ArgumentError(
              "Object with name $instanceName has a different type (${registeredObject.registrationType.toString()}) than the one that is inferred (${T.toString()}) where you call it");
        }
```

`registeredObject.registrationType` is of Type `Type` and `T` is of Type `String` (in this case), so the comparison fails.
This only works if the caller does not use generic type parameters, because then `T` is of type `dynamic`, and `dynamic` is a bottom type, so the `X is dynamic` is always true.

This PR fixes this by checking the type of the actual instance.
I also added a test for this.
