### PR TITLE
Bug fix for async singleton factory method and fixing example code

### DIFF
--- a/example/lib/app_model.dart
+++ b/example/lib/app_model.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
-import 'main.dart';
-
 abstract class AppModel extends ChangeNotifier {
   void incrementCounter();
 
@@ -15,7 +13,9 @@ class AppModelImplementation extends AppModel {
 
   AppModelImplementation(Completer completer) {
     /// lets pretend we have to do some async initilization
-    Future.delayed(Duration(seconds: 3)).then((_) => completer.complete());
+    Future.delayed(Duration(seconds: 3)).then((_) {
+      completer.complete();
+    });
   }
 
   @override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
-import 'package:get_it_example/app_model.dart';
+
+import 'app_model.dart';
 
 // This is our global ServiceLocator
 GetIt getIt = GetIt.instance;
 
 void main() {
-  
-  getIt.registerSingletonAsync<AppModel>((completer) => AppModelImplementation(completer));
+  getIt.registerSingletonAsync<AppModel>(
+      (completer) => AppModelImplementation(completer));
 
   runApp(MyApp());
 }
@@ -39,9 +40,7 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   initState() {
     // Access the instance of the registered AppModel
-    getIt<AppModel>().addListener(update);
-    // Alternative
-    // getIt.get<AppModel>().addListener(update);
+    getIt.getAsync<AppModel>().then((model) => model.addListener(update));
 
     super.initState();
   }
@@ -56,47 +55,55 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.title),
-      ),
-      body: Center(
-        child: FutureBuilder(
-            future: getIt.allReady(),
-            builder: (context, snapshot) {
-              if (snapshot.hasData) {
-                return Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    Text(
-                      'You have pushed the button this many times:',
-                    ),
-                    Text(
-                      '${getIt<AppModel>().counter}',
-                      style: Theme.of(context).textTheme.display1,
-                    ),
-                  ],
-                );
-              } else {
-                return Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text('Waiting for initialisation'),
-                    SizedBox(
-                      height: 16,
-                    ),
-                    CircularProgressIndicator(),
-                  ],
-                );
-              }
-            }),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: getIt<AppModel>().incrementCounter,
-        tooltip: 'Increment',
-        child: Icon(Icons.add),
-      ),
+    return FutureBuilder(
+      future: getIt.allReady(),
+      builder: (context, snapshot) {
+        if (snapshot.hasData) {
+          return Scaffold(
+            appBar: AppBar(
+              title: Text(widget.title),
+            ),
+            body: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  Text(
+                    'You have pushed the button this many times:',
+                  ),
+                  Text(
+                    '${getIt<AppModel>().counter}',
+                    style: Theme.of(context).textTheme.display1,
+                  ),
+                ],
+              ),
+            ),
+            floatingActionButton: FloatingActionButton(
+              onPressed: getIt<AppModel>().incrementCounter,
+              tooltip: 'Increment',
+              child: Icon(Icons.add),
+            ),
+          );
+        } else {
+          return Scaffold(
+            appBar: AppBar(
+              title: Text(widget.title),
+            ),
+            body: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text('Waiting for initialisation'),
+                  SizedBox(
+                    height: 16,
+                  ),
+                  CircularProgressIndicator(),
+                ],
+              ),
+            ),
+          );
+        }
+      },
     );
   }
 }

--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -434,7 +434,7 @@ class _GetItImplementation implements GetIt {
               return instance;
             });
           } else {
-            serviceFactory.instance = instance;
+            serviceFactory.instance = asyncResult;
             // In this case the instance has to complete the completer
             isReadyFuture = Future.value(asyncResult);
           }
@@ -553,7 +553,9 @@ class _GetItImplementation implements GetIt {
     FutureGroup futures = FutureGroup();
     _factories.values
         .followedBy(_factoriesByName.values)
-        .where((x) => (x.isAsync && !x.isReady && x.factoryType ==_ServiceFactoryType.constant ))
+        .where((x) => (x.isAsync &&
+            !x.isReady &&
+            x.factoryType == _ServiceFactoryType.constant))
         .forEach((f) => futures.add(f._readyCompleter.future));
     futures.close();
     if (timeout != null) {


### PR DESCRIPTION
There were several errors in the example code that were causing it to throw errors. 

* The `initState` method was calling `get` directly instead of `getAsync`, and there's no way the future started in the singleton initialization was going to be done by then. This caused the "You tried to access an instance of AppModel that was not ready yet" error to be thrown.
* Similarly, the `FloatingActionButton` was declared outside of the `FutureBuilder` but still attempted to call `get` on the resource. This was resolved by moving the `FutureBuilder` to the top of the returned widget tree.

Furthermore, there was an error in the `_register` method in `GetItImpl` when calling `registerSingletonAsync` with a provider that returned an instance of `T` rather than a `Future<T>`. 
* The method was assigning `instance` to `serviceFactory.instance`, but when `_register` is called via `registerSingletonAsync`. `instance` is defined to be null. This caused an issue later on when calling `get`, as a value of type `Null` cannot be coerced to `AppModel` (i.e. `null is AppModel` will always return false), leading to an error to be thrown with the confusing message: "Object with name has a different type (AppModel) than the one that is inferred (AppModel) where you call it". 

* This was fixed by changing the line: `serviceFactory.instance = instance;` to: `serviceFactory.instance = asyncResult;`