### PR TITLE
Remove unnecessary print statement

### DIFF
--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -530,8 +530,6 @@ class _GetItImplementation implements GetIt {
     Iterable<Type> dependsOn,
     @required bool shouldSignalReady,
   }) {
-    print(T.toString());
-
     throwIf(
       (!(const Object() is! T) && (instanceName == null)),
       'GetIt: You have to provide either a type or a name. Did you accidentally do  `var sl=GetIt.instance();` instead of var sl=GetIt.instance;',


### PR DESCRIPTION
Do we really need this print statement? It looks unnecessary to me. 
Or we can add a check for debug builds only.

A screenshot of my logcat.
![Screenshot from 2020-03-10 01-42-43](https://user-images.githubusercontent.com/25670178/76253412-ae65fc80-6270-11ea-9ddc-ba20fe2dcc2c.png)
