### PR TITLE
change equality-check to is-check to allow subtypes

### DIFF
--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -105,11 +105,11 @@ class _ServiceFactory<T, P1, P2> {
         case _ServiceFactoryType.alwaysNew:
           if (creationFunctionParam != null) {
             assert(
-                param1 == null || param1.runtimeType == param1Type,
+                param1 == null || param1 is P1,
                 'Incompatible Type passed as param1\n'
                 'expected: $param1Type actual: ${param1.runtimeType}');
             assert(
-                param2 == null || param2.runtimeType == param2Type,
+                param2 == null || param2 is P2,
                 'Incompatible Type passed as param2\n'
                 'expected: $param2Type actual: ${param2.runtimeType}');
             return creationFunctionParam(param1 as P1, param2 as P2);
@@ -153,11 +153,11 @@ class _ServiceFactory<T, P1, P2> {
         case _ServiceFactoryType.alwaysNew:
           if (asyncCreationFunctionParam != null) {
             assert(
-                param1 == null || param1.runtimeType == param1Type,
+                param1 == null || param1 is P1,
                 'Incompatible Type passed a param1\n'
                 'expected: $param1Type actual: ${param1.runtimeType}');
             assert(
-                param2 == null || param2.runtimeType == param2Type,
+                param2 == null || param2 is P2,
                 'Incompatible Type passed a param2\n'
                 'expected: $param2Type actual: ${param2.runtimeType}');
             return asyncCreationFunctionParam(param1 as P1, param2 as P2)

--- a/test/async_test.dart
+++ b/test/async_test.dart
@@ -17,6 +17,17 @@ class TestClassParam {
   TestClassParam({this.param1, this.param2});
 }
 
+class TestParamType{
+  final String name;
+
+  TestParamType({this.name});  
+}
+
+class TestParamSubType extends TestParamType{
+
+  TestParamSubType({String name}) : super(name: name);
+}
+
 class TestClass extends TestBaseClass{
   GetIt getIt;
 
@@ -545,6 +556,28 @@ void main() {
     expect(instance2.param1, '123');
     expect(instance2.param2, 5);
   });
+
+  test('register factory with subtype of Param', () async {
+    var getIt = GetIt.instance;
+    getIt.reset();
+
+    constructorCounter = 0;
+    getIt.registerFactoryParamAsync<TestClassParam, TestParamType, void>((s, _) async {
+      await Future.delayed(Duration(milliseconds: 1));
+      return TestClassParam(param1: s.name);
+    });
+
+    //var instance1 = getIt.get<TestBaseClass>();
+
+    var instance1 = await getIt.getAsync<TestClassParam>(param1: TestParamSubType(name:'abc'));
+    var instance2 = await getIt.getAsync<TestClassParam>(param1: TestParamSubType(name:'123'));
+
+    expect(instance1 is TestClassParam, true);
+    expect(instance1.param1, 'abc');
+    expect(instance2 is TestClassParam, true);
+    expect(instance2.param1, '123');
+  });
+
 
   test('register factory with Params with wrong type', () {
     var getIt = GetIt.instance;

--- a/test/get_it_test.dart
+++ b/test/get_it_test.dart
@@ -30,6 +30,17 @@ class TestClassParam {
   TestClassParam({this.param1, this.param2});
 }
 
+class TestParamType{
+  final String name;
+
+  TestParamType({this.name});  
+}
+
+class TestParamSubType extends TestParamType{
+
+  TestParamSubType({String name}) : super(name: name);
+}
+
 void main() {
   setUp(() {
     //make sure the instance is cleared before each test
@@ -96,6 +107,25 @@ void main() {
     expect(instance2 is TestClassParam, true);
     expect(instance2.param1, '123');
     expect(instance2.param2, 5);
+  });
+
+    test('register factory with subtype of Param', () {
+    var getIt = GetIt.instance;
+    getIt.reset();
+
+    constructorCounter = 0;
+    getIt.registerFactoryParam<TestClassParam, TestParamType, void>(
+        (s, _) => TestClassParam(param1: s.name));
+
+    //var instance1 = getIt.get<TestBaseClass>();
+
+    var instance1 = getIt<TestClassParam>(param1: TestParamSubType(name:'abc'));
+    var instance2 = getIt<TestClassParam>(param1: TestParamSubType(name:'123'));
+
+    expect(instance1 is TestClassParam, true);
+    expect(instance1.param1, 'abc');
+    expect(instance2 is TestClassParam, true);
+    expect(instance2.param1, '123');
   });
 
   test('register factory with Params with wrong type', () {


### PR DESCRIPTION
Change param type checking from `==` to `is` to allow subtypes of param type. See #62