### PR TITLE
Minor change in Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a simple **Service Locator** for Dart and Flutter projects with some add
 
 Typical usage:
 * Accessing service objects like REST API clients or databases so that they easily can be mocked.
-* Accessing View/AppModels/Managers/BLoCs from Flutter Views
+* Accessing View/AppModels/Managers/BLoCs from Flutter Widgets
 
 >**Breaking Change with V4.0.0** 
 Principle on how to synchronize your registered instances creation has been rethought and improved :smiley:.


### PR DESCRIPTION
This is not a big change by any means but the word `Widget` sounds more native than `View` when we are talking about `Flutter Apps`. 
I also suspect that you might have named it View with specific reason instead of Widgets intentionally. If so can I know the reason, please?