### PR TITLE
fix #160: bump to null-safety prerelease versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: get_it
 description: Simple direct Service Locator that allows to decouple the interface from a concrete implementation and  to access the concrete implementation from everywhere in your App"
-version: 6.0.0-nullsafety.2
+version: 6.0.0
 maintainer: Thomas Burkhart (@escamoteur)
 authors:
 - Flutter Community <community@flutter.zone>
@@ -12,10 +12,10 @@ environment:
   sdk: '>=2.12.0-29.10.beta <3.0.0'
 
 dependencies:
-  async: ^2.5.0-nullsafety.3
-  collection: 1.15.0-nullsafety.5
-  meta: ^1.3.0-nullsafety.6
+  async: ^2.5.0
+  collection: 1.15.0
+  meta: ^1.3.0
 
 dev_dependencies:
   lint: ^1.2.0
-  test: 1.16.0-nullsafety.12
+  test: 1.16.2


### PR DESCRIPTION
bumping Flutter dependencies to their prerelease versions since 1.26 got bumped to the beta channel.