### PR TITLE
Fix StateError when unregistering non-async singletons other singletons are dependent on

### DIFF
--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -929,6 +929,7 @@ class _GetItImplementation implements GetIt {
             isReadyFuture = Future<T>.value(serviceFactory.instance as T);
             serviceFactory._readyCompleter
                 .complete(serviceFactory.instance as T);
+            serviceFactory.objectsWaiting.clear();
           } else {
             isReadyFuture = serviceFactory._readyCompleter.future;
           }


### PR DESCRIPTION
When registering a singleton that other singletons are dependent on, the instance's `objectsWaiting` list gets filled with the dependent singletons. This list is cleared for async singletons, when they have been created, as of [fix for #210](https://github.com/fluttercommunity/get_it/commit/dd9ad516c3d5b25a8350cd95cfc64884928e01a5).

The list is not cleared for non-async singletons, which results in them being unable to be unregistered at any time with the `StateError(
          'There are still other objects waiting for this instance so signal ready'`.

This PR fixes the unexpected exception by clearing the `objectsWaiting` when a non-async singleton has been initialized.