### PR TITLE
Return the instance when calling registerSingleton

### DIFF
--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -259,7 +259,7 @@ abstract class GetIt {
   /// If [signalsReady] is set to `true` it means that the future you can get from `allReady()`
   /// cannot complete until this this instance was signalled ready by calling
   /// [signalsReady(instance)].
-  void registerSingleton<T extends Object>(
+  T registerSingleton<T extends Object>(
     T instance, {
     String? instanceName,
     bool? signalsReady,

--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -578,7 +578,7 @@ class _GetItImplementation implements GetIt {
   /// registered with that name instead of a type. This should only be necessary if you need
   /// to register more than one instance of one type. It's highly not recommended
   @override
-  void registerSingleton<T extends Object>(
+  T registerSingleton<T extends Object>(
     T instance, {
     String? instanceName,
     bool? signalsReady,
@@ -592,6 +592,7 @@ class _GetItImplementation implements GetIt {
       shouldSignalReady: signalsReady ?? <T>[] is List<WillSignalReady>,
       disposeFunc: dispose,
     );
+    return instance;
   }
 
   /// registers a type as Singleton by passing an factory function of that type


### PR DESCRIPTION
Just a convenience feature so you can write code like this:
```dart
final instance = GetIt.I.registerSingleton(Object());
```