### PR TITLE
Reset a lazy Singleton by providing an instance.

### DIFF
--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -408,7 +408,7 @@ abstract class GetIt {
   /// provide a [disposingFunction]. This function overrides the disposing
   /// you might have provided when registering.
   FutureOr resetLazySingleton<T extends Object>({
-    Object? instance,
+    T? instance,
     String? instanceName,
     FutureOr Function(T)? disposingFunction,
   });

--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -1033,7 +1033,7 @@ class _GetItImplementation implements GetIt {
   /// provide a [disposingFunction]
   @override
   FutureOr resetLazySingleton<T extends Object>({
-    Object? instance,
+    T? instance,
     String? instanceName,
     FutureOr Function(T)? disposingFunction,
   }) async {

--- a/test/get_it_test.dart
+++ b/test/get_it_test.dart
@@ -509,6 +509,24 @@ void main() {
     GetIt.I.reset();
   });
 
+  test('reset LazySingleton by instance only', () {
+    // Arrange
+    final getIt = GetIt.instance;
+    constructorCounter = 0;
+    getIt.registerLazySingleton<TestClass>(() => TestClass());
+    final instance1 = getIt.get<TestClass>();
+
+    // Act
+    GetIt.I.resetLazySingleton(instance: instance1);
+
+    // Assert
+    final instance2 = getIt.get<TestClass>();
+    expect(instance1, isNot(instance2));
+    expect(constructorCounter, 2);
+
+    GetIt.I.reset();
+  });
+
   test('unregister by instance when the dispose of the register is a future',
       () async {
     final getIt = GetIt.instance;


### PR DESCRIPTION
**Current version:**
GetIt.I.resetLazySingleton(instance: YOUR-INSTANCE) throws when the generic is omitted.

**New version:**
Allows to reset the lazy Singleton by only providing an instance.



