### PR TITLE
Added flag to suppress the printing of error messages. 

### DIFF
--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -142,8 +142,8 @@ abstract class GetIt {
 
   /// If you need more than one instance of GetIt you can use [asNewInstance()]
   /// You should prefer to use the `instance()` method to access the global instance of [GetIt].
-  factory GetIt.asNewInstance() {
-    return _GetItImplementation();
+  factory GetIt.asNewInstance({bool quietErrors = false}) {
+    return _GetItImplementation(quietErrors: quietErrors);
   }
 
   /// By default it's not allowed to register a type a second time.

--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -180,10 +180,12 @@ class _ServiceFactory<T extends Object, P1, P2> {
           throw StateError('Impossible factoryType');
       }
     } catch (e, s) {
-      // ignore: avoid_print
-      print('Error while creating ${T.toString()}');
-      // ignore: avoid_print
-      print('Stack trace:\n $s');
+      if(!_getItInstance.quietErrors) {
+        // ignore: avoid_print
+        print('Error while creating ${T.toString()}');
+        // ignore: avoid_print
+        print('Stack trace:\n $s');
+      }
       rethrow;
     }
   }
@@ -270,10 +272,12 @@ class _ServiceFactory<T extends Object, P1, P2> {
           throw StateError('Impossible factoryType');
       }
     } catch (e, s) {
-      // ignore: avoid_print
-      print('Error while creating ${T.toString()}');
-      // ignore: avoid_print
-      print('Stack trace:\n $s');
+      if(!_getItInstance.quietErrors) {
+        // ignore: avoid_print
+        print('Error while creating ${T.toString()}');
+        // ignore: avoid_print
+        print('Stack trace:\n $s');
+      }
       rethrow;
     }
   }
@@ -309,6 +313,11 @@ class _GetItImplementation implements GetIt {
   final _scopes = [_Scope(name: _baseScopeName)];
 
   _Scope get _currentScope => _scopes.last;
+
+  // If this is set do not print errors
+  final bool quietErrors;
+
+  _GetItImplementation({this.quietErrors = false});
 
   @override
   void Function(bool pushed)? onScopeChanged;


### PR DESCRIPTION
Added flag to suppress the printing of error messages. 
When a user is catching the error themselves and logging it this print is intrusive and should not appear. Default set to false to maintain past behaviour.