### PR TITLE
create a new instance even if dispose is not completed after resetLaz…

### DIFF
--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -1083,16 +1083,17 @@ class _GetItImplementation implements GetIt {
           'There is no type ${instance.runtimeType} registered as LazySingleton in GetIt'),
     );
 
+    Future<dynamic> _dispose = Future.value();
     if (instanceFactory.instance != null) {
       if (disposingFunction != null) {
         final dispose = disposingFunction.call(instanceFactory.instance as T);
         if (dispose is Future) {
-          await dispose;
+          _dispose = dispose;
         }
       } else {
         final dispose = instanceFactory.dispose();
         if (dispose is Future) {
-          await dispose;
+          _dispose = dispose;
         }
       }
     }
@@ -1100,6 +1101,7 @@ class _GetItImplementation implements GetIt {
     instanceFactory.instance = null;
     instanceFactory.pendingResult = null;
     instanceFactory._readyCompleter = Completer<T>();
+    await _dispose;
   }
 
   List<_ServiceFactory> get _allFactories =>

--- a/test/get_it_test.dart
+++ b/test/get_it_test.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: unnecessary_type_check, avoid_redundant_argument_values, avoid_classes_with_only_static_members
+import 'dart:async';
 
 import 'package:get_it/get_it.dart';
 import 'package:test/test.dart';
@@ -527,6 +528,27 @@ void main() {
     expect(constructorCounter, 2);
 
     GetIt.I.reset();
+  });
+
+  test(
+      'create a new instance even if dispose is not completed after resetLazySingleton',
+      () {
+    // Arrange
+    final completer = Completer();
+    GetIt.I.registerLazySingleton<TestClass>(
+      () => TestClass(),
+      dispose: (_) => completer.future,
+    );
+    final instance1 = GetIt.I.get<TestClass>();
+
+    // Act
+    GetIt.I.resetLazySingleton(instance: instance1);
+
+    // Assert
+    final instance2 = GetIt.I.get<TestClass>();
+    expect(instance1, isNot(instance2));
+
+    completer.complete();
   });
 
   test('unregister by instance when the dispose of the register is a future',


### PR DESCRIPTION
In app i need to `resetLazySingleton` in `dispose` (sync) method in statefull widget. My service dispose method is async and takes long time. Once i am back in widget, `Get.I<Foo>()` returns me same instance, with on going dispose. For now, the only way to avoid that is to register dispose function as non-Future, like:
```
GetIt.I.registerLazySingleton<Foo>(
    () => Foo(),
    dispose: (foo) {
      foo.dispose();
    },
  );
```
but here, `await resetLazySingleton<Foo>()` will not await my dispose function and nowhere i am able to wait for it. Also from convention, i don't see a point, where i would need to get again (almost) disposed instance - so i think its buggy.

I think:
1. `resetLazySingleton<Foo>(); return Get.I<Foo>();` should return a new instance;
2. `await resetLazySingleton<Foo>()` should await for dispose function with Future type.