### PR TITLE
add punctuation to `registerFactory`

### DIFF
--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -179,8 +179,8 @@ abstract class GetIt {
   });
 
   /// registers a type so that a new instance will be created on each call of [get] on that type
-  /// [T] type to register
-  /// [factoryFunc] factory function for this type
+  /// [T] type to register,
+  /// [factoryFunc] factory function for this type,
   /// [instanceName] if you provide a value here your factory gets registered with that
   /// name instead of a type. This should only be necessary if you need to register more
   /// than one instance of one type. Its highly not recommended.


### PR DESCRIPTION
It's quite hard to read and understand the documentation for `registerFactory` from VSCode.  I believe adding punctuation where necessary will go along way to help developers get a quick grasp "on-the-go"