### PR TITLE
Added type as T, else the assert statement fails

### DIFF
--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -1015,7 +1015,7 @@ class _GetItImplementation implements GetIt {
     if (instance != null) {
       return _findFirstFactoryByInstanceOrNull(instance) != null;
     } else {
-      return _findFirstFactoryByNameAndTypeOrNull<T>(instanceName) != null;
+      return _findFirstFactoryByNameAndTypeOrNull<T>(instanceName, type: T) != null;
     }
   }
 


### PR DESCRIPTION
Passing the type as generic T, else even though a Factory is registered, `the isRegistered()` would return false. As `_scopes[T]` would return `null`.