### PR TITLE
Added hasScope api to easily verify if the scope already pushed before

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,9 @@ Another example could be a shopping basket where you want to ensure that not a c
   /// As dispose functions can be async, you should await this function.
   Future<void> dropScope(String scopeName);
 
+  /// Tests if the scope by name [scopeName] is registered in GetIt
+  bool hasScope(String scopeName);
+
   /// Clears all registered types for the current scope
   /// If you provided dispose function when registering they will be called
   /// [dispose] if `false` it only resets without calling any dispose
@@ -516,7 +519,7 @@ In some cases, it's handy if you could pass changing values to factories when ca
 /// [factoryfunc] factory function for this type that accepts two parameters
 /// [instanceName] if you provide a value here your factory gets registered with that
 /// name instead of a type. This should only be necessary if you need to register more
-/// than one instance of one type. 
+/// than one instance of one type.
 ///
 /// example:
 ///    getIt.registerFactoryParam<TestClassParam,String,int>((s,i)

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -427,6 +427,9 @@ abstract class GetIt {
   /// As dispose functions can be async, you should await this function.
   Future<void> dropScope(String scopeName);
 
+  /// Tests if the scope by name [scopeName] is registered in GetIt
+  bool hasScope(String scopeName);
+
   /// Returns the name of the current scope if it has one otherwise null
   /// if you are already on the baseScope it returns 'baseScope'
   String? get currentScopeName;

--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -888,6 +888,12 @@ class _GetItImplementation implements GetIt {
     _scopes.remove(scope);
   }
 
+  /// Tests if the scope by name [scopeName] is registered in GetIt
+  @override
+  bool hasScope(String scopeName) {
+    return _scopes.any((x) => x.name == scopeName);
+  }
+
   @override
   String? get currentScopeName => _currentScope.name;
 

--- a/test/scope_test.dart
+++ b/test/scope_test.dart
@@ -11,9 +11,11 @@ abstract class TestBaseClass {}
 
 class TestClass extends TestBaseClass {
   final String? id;
+
   TestClass([this.id]) {
     constructorCounter++;
   }
+
   void dispose() {
     disposeCounter++;
   }
@@ -27,6 +29,7 @@ class TestClassShadowChangHandler extends TestBaseClass
   TestClassShadowChangHandler(this.onShadowChange, [this.id]) {
     constructorCounter++;
   }
+
   void dispose() {
     disposeCounter++;
   }
@@ -44,7 +47,9 @@ class TestClassShadowChangHandler extends TestBaseClass
 
 class TestClass2 {
   final String? id;
+
   TestClass2([this.id]);
+
   void dispose() {
     disposeCounter++;
   }
@@ -685,6 +690,23 @@ void main() {
     );
     expect(getIt<TestClass>(instanceName: 'scope3'), isNotNull);
   });
+
+  test(
+    'has registered scope test',
+    () async {
+      final getIt = GetIt.instance;
+      getIt.pushNewScope(scopeName: 'scope1');
+      getIt.pushNewScope(scopeName: 'scope2');
+      getIt.pushNewScope(scopeName: 'scope3');
+
+      expect(getIt.hasScope('scope2'), isTrue);
+      expect(getIt.hasScope('scope4'), isFalse);
+
+      await getIt.dropScope('scope2');
+
+      expect(getIt.hasScope('scope2'), isFalse);
+    },
+  );
 
   test('full reset no dispose', () async {
     final getIt = GetIt.instance;


### PR DESCRIPTION
In some cases, I need to check if the scope that I'm trying to push has already been pushed before.
There is an option to do it by setting the onScopeChanged callback and managing the scope changes in a stack somewhere in my sources, but as GetIt already manages the list of scopes, I believe the new `hasScope()` API can be a better way to check it.