### PR TITLE
Update get_it_impl.dart to dispose in reverse order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,29 @@
-[7.6.5] - 25.09.2023 updated Discord link
-[7.6.4] -04.09.2023 fixed the throwing of a StateError that was previously thrown as String
-[7.6.3] -04.09.2023 push new version because pub didn't list this one
-[7.6.2] -31.08.2023 fix linter error
-[7.6.1] - 31.08.2023 version bump of dependencies and updates readme
-[7.6.0] - 09.05.2023
+## [7.6.6] - 04.01.2024
+
+* `getIt.reset, getIt.popScope, getIt.dropScope` now dispose services in the reverse order in which they were registered.
+
+## [7.6.5] - 25.09.2023
+
+* updated Discord link
+
+## [7.6.4] - 04.09.2023
+
+* fixed the throwing of a StateError that was previously thrown as String
+
+## [7.6.3] - 04.09.2023
+
+* push new version because pub didn't list this one
+
+## [7.6.2] - 31.08.2023
+
+* fix linter error
+
+## [7.6.1] - 31.08.2023
+
+* version bump of dependencies and updates readme
+
+## [7.6.0] - 09.05.2023
+
 * merged PR by lacopiroty https://github.com/fluttercommunity/get_it/pull/297 which now allows to access objects inside GetIt by runtime type too like
 ```Dart
     getIt.registerSingleton(TestClass());
@@ -16,7 +36,7 @@
 * fix for https://github.com/fluttercommunity/get_it/issues/300    
 
 
-[7.5.0] - 07.05.2023
+## [7.5.0] - 07.05.2023
 
 * new function `dropScope(scopeName)` which allows to remove and dispose any named scope even if it's not the top one. Great PR by @olexale https://github.com/fluttercommunity/get_it/pull/292 which fixes sort of race conditions if you create scopes just for the life time of a widget. 
 ## [7.4.1]

--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ void resetLazySingleton<T>({Object instance,
 ### Resetting GetIt completely
 
 ```Dart
-/// Clears all registered types. Handy when writing unit tests
+/// Disposes all registered types in the reverse order in which they were registered.
+/// Handy when writing unit tests or before quitting your application.
 /// If you provided dispose function when registering they will be called
 /// [dispose] if `false` it only resets without calling any dispose
 /// functions
@@ -245,7 +246,7 @@ Another example could be a shopping basket where you want to ensure that not a c
   /// If no scope with [name] exists, nothing is popped and `false` is returned
   Future<bool> popScopesTill(String name, {bool inclusive = true});
 
-  /// Disposes all registered factories and singletons in the provided scope,
+  /// Clears all registered factories and singletons in the provided scope,
   /// then destroys (drops) the scope. If the dropped scope was the last one,
   /// the previous scope becomes active again.
   /// if you provided dispose functions on registration, they will be called.
@@ -257,7 +258,7 @@ Another example could be a shopping basket where you want to ensure that not a c
   /// Tests if the scope by name [scopeName] is registered in GetIt
   bool hasScope(String scopeName);
 
-  /// Clears all registered types for the current scope
+  /// Clears all registered types for the current scope in the reverse order in which they were registered.
   /// If you provided dispose function when registering they will be called
   /// [dispose] if `false` it only resets without calling any dispose
   /// functions

--- a/doc/api/get_it/GetIt/reset.html
+++ b/doc/api/get_it/GetIt/reset.html
@@ -112,7 +112,7 @@
       
     </section>
     <section class="desc markdown">
-      <p>Clears all registered types. Handy when writing unit tests</p>
+      <p>Clears all registered types in the reverse order in which they were registered. Handy when writing unit tests and when you need to dispose services that depend on each other.</p>
     </section>
     
     <section class="summary source-code" id="source">

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -3,6 +3,7 @@
 library get_it;
 
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:async/async.dart';
 import 'package:collection/collection.dart' show IterableExtension;
@@ -359,14 +360,15 @@ abstract class GetIt {
   /// is registered inside GetIt
   bool isRegistered<T extends Object>({Object? instance, String? instanceName});
 
-  /// Clears all registered types. Handy when writing unit tests
+  /// Clears all registered types in the reverse order in which they were registered.
+  /// Handy when writing unit tests or when disposing services that depend on each other.
   /// If you provided dispose function when registering they will be called
   /// [dispose] if `false` it only resets without calling any dispose
   /// functions
   /// As dispose functions can be async, you should await this function.
   Future<void> reset({bool dispose = true});
 
-  /// Clears all registered types for the current scope
+  /// Clears all registered types for the current scope in the reverse order of registering them.
   /// If you provided dispose function when registering they will be called
   /// [dispose] if `false` it only resets without calling any dispose
   /// functions
@@ -419,7 +421,8 @@ abstract class GetIt {
   /// If no scope with [name] exists, nothing is popped and `false` is returned
   Future<bool> popScopesTill(String name, {bool inclusive = true});
 
-  /// Disposes all registered factories and singletons in the provided scope,
+  /// Disposes all registered factories and singletons in the provided scope
+  /// (in the reverse order in which they were registered),
   /// then destroys (drops) the scope. If the dropped scope was the last one,
   /// the previous scope becomes active again.
   /// if you provided dispose functions on registration, they will be called.

--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -309,7 +309,7 @@ class _Scope {
 
   Future<void> reset({required bool dispose}) async {
     if (dispose) {
-      for (final factory in allFactories) {
+      for (final factory in allFactories.reversed) {
         await factory.dispose();
       }
     }

--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -302,8 +302,9 @@ class _Scope {
   final String? name;
   final ScopeDisposeFunc? disposeFunc;
   bool isFinal = false;
-  final factoriesByName =
-      <String?, Map<Type, _ServiceFactory<Object, dynamic, dynamic>>>{};
+  // ignore: prefer_collection_literals
+  final factoriesByName = LinkedHashMap<String?,
+      LinkedHashMap<Type, _ServiceFactory<Object, dynamic, dynamic>>>();
 
   _Scope({this.name, this.disposeFunc});
 
@@ -753,7 +754,7 @@ class _GetItImplementation implements GetIt {
     await resetScope(dispose: dispose);
   }
 
-  /// Clears all registered types of the current scope.
+  /// Clears all registered types of the current scope in the reverse order in which they were registered.
   @override
   Future<void> resetScope({bool dispose = true}) async {
     if (dispose) {
@@ -829,6 +830,7 @@ class _GetItImplementation implements GetIt {
   }
 
   /// Disposes all factories/Singletons that have been registered in this scope
+  /// (in the reverse order in which they were registered)
   /// and pops (destroys) the scope so that the previous scope gets active again.
   /// if you provided dispose functions on registration, they will be called.
   /// if you passed a dispose function when you pushed this scope it will be
@@ -875,7 +877,8 @@ class _GetItImplementation implements GetIt {
     return true;
   }
 
-  /// Disposes all registered factories and singletons in the provided scope,
+  /// Disposes all registered factories and singletons in the provided scope
+  /// (in the reverse order in which they were registered),
   /// then drops (destroys) the scope. If the dropped scope was the last one,
   /// the previous scope becomes active again.
   /// if you provided dispose functions on registration, they will be called.
@@ -985,7 +988,7 @@ class _GetItImplementation implements GetIt {
 
     factoriesByName.putIfAbsent(
       instanceName,
-      () => <Type, _ServiceFactory<Object, dynamic, dynamic>>{},
+      () => LinkedHashMap<Type, _ServiceFactory<Object, dynamic, dynamic>>(),
     );
     factoriesByName[instanceName]![T] = serviceFactory;
 


### PR DESCRIPTION
There are a few situations, where one instance depends on an instance you created before.
In all of these situations, it makes more sense to dispose of the widgets in reverse order.