### PR TITLE
fix: skipDoubleRegistration with instanceName

### DIFF
--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -1586,7 +1586,9 @@ class _GetItImplementation implements GetIt {
         );
 
         /// skip double registration
-        if (skipDoubleRegistration && !allowReassignment) {
+        if (skipDoubleRegistration &&
+            !allowReassignment &&
+            existingTypeRegistration.namedFactories.containsKey(instanceName)) {
           return;
         }
       } else {

--- a/test/skip_double_registration_test.dart
+++ b/test/skip_double_registration_test.dart
@@ -38,6 +38,27 @@ void main() {
     expect(getIt<DataStore>(), isA<MockDataStore>());
   });
 
+  test(' Ignores Double named registration error ', () async {
+    final getIt = GetIt.instance;
+    const instanceName = 'named';
+    getIt.reset();
+    getIt.allowReassignment = false;
+    getIt.skipDoubleRegistration = true;
+    getIt.registerSingleton<DataStore>(RemoteDataStore());
+    getIt.registerSingleton<DataStore>(
+      MockDataStore(),
+      instanceName: instanceName,
+    );
+    getIt.registerSingleton<DataStore>(MockDataStore());
+    getIt.registerSingleton<DataStore>(
+      RemoteDataStore(),
+      instanceName: instanceName,
+    );
+
+    expect(getIt<DataStore>(), isA<RemoteDataStore>());
+    expect(getIt<DataStore>(instanceName: instanceName), isA<MockDataStore>());
+  });
+
   test(' does not care about [skipDoubleRegistration] varibale   ', () async {
     final getIt = GetIt.instance;
     getIt.reset();


### PR DESCRIPTION
### Fix for `skipDoubleRegistration` behavior

#### Description
This PR fixes the behavior of the `skipDoubleRegistration` parameter. Previously, it ignored registration regardless of the `instanceName` value. Now, registration is only skipped if the `instanceName` matches, which is the expected behavior.

#### Changes made:
- Updated the logic for `skipDoubleRegistration` to take `instanceName` into account when deciding whether to skip registration.

#### Why this is important:
This fix prevents situations where a registration could be mistakenly skipped even with different `instanceName` values, which caused incorrect behavior in certain scenarios.

#### Testing:
- Tested with both unnamed registrations and those with `instanceName` values to ensure that registration is only skipped when names are the same and works as expected otherwise.