### PR TITLE
Implement new methods for GetIt service locator

### DIFF
--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -152,6 +152,9 @@ abstract class GetIt {
   /// If you really need to you can disable the asserts by setting[allowReassignment]= true
   bool allowReassignment = false;
 
+  /// Returns true if the app is running in debug mode
+  bool get isDebugMode;
+
   /// By default it's throws error when [allowReassignment]= false. and trying to register same type
   /// If you really need, you can disable the Asserts / Error by setting[skipDoubleRegistration]= true
   @visibleForTesting
@@ -580,19 +583,12 @@ abstract class GetIt {
   /// if referenceCount is 0
   /// [ignoreReferenceCount] if `true` it will ignore the reference count and unregister the object
   /// only use this if you know what you are doing
+  /// [fromAllScopes] if `true` it will unregister the instance from all scopes, not just the current one
   FutureOr unregister<T extends Object>({
     Object? instance,
     String? instanceName,
     FutureOr Function(T)? disposingFunction,
     bool ignoreReferenceCount = false,
-  });
-
-  /// Unregisters an instance of an object or a factory/singleton by Type [T] or by name [instanceName]
-  /// [fromAllScopes] if true, unregisters from all scopes, not just the current one
-  FutureOr unregisterFromScopes<T extends Object>({
-    Object? instance,
-    String? instanceName,
-    FutureOr Function(T)? disposingFunction,
     bool fromAllScopes = false,
   });
 

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -647,4 +647,13 @@ abstract class GetIt {
   /// Or use async registrations methods or let individual instances signal their ready
   /// state on their own.
   void signalReady(Object? instance);
+
+  /// Returns the number of times a singleton has been accessed.
+  int getAccessCount<T extends Object>({String? instanceName});
+
+  /// Clears all instances of a specific type, including named instances.
+  Future<void> clearAllInstances<T extends Object>();
+
+  /// Sets a default instance for a type, replacing the existing one if present.
+  void setDefault<T extends Object>(T instance, {String? instanceName});
 }

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -152,9 +152,6 @@ abstract class GetIt {
   /// If you really need to you can disable the asserts by setting[allowReassignment]= true
   bool allowReassignment = false;
 
-  /// Returns true if the app is running in debug mode
-  bool get isDebugMode;
-
   /// By default it's throws error when [allowReassignment]= false. and trying to register same type
   /// If you really need, you can disable the Asserts / Error by setting[skipDoubleRegistration]= true
   @visibleForTesting
@@ -656,6 +653,10 @@ abstract class GetIt {
   /// Returns the number of times a singleton has been accessed.
   /// Only available in debug mode.
   int getAccessCount<T extends Object>({String? instanceName});
+
+  /// Reset the number of times a singleton has been accessed.
+  /// Only available in debug mode.
+  void resetAccessCount<T extends Object>({String? instanceName});
 
   /// Replaces an existing singleton instance with a new instance.
   /// Throws if the instance is not found or is not a singleton.

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -587,6 +587,15 @@ abstract class GetIt {
     bool ignoreReferenceCount = false,
   });
 
+  /// Unregisters an instance of an object or a factory/singleton by Type [T] or by name [instanceName]
+  /// [fromAllScopes] if true, unregisters from all scopes, not just the current one
+  FutureOr unregisterFromScopes<T extends Object>({
+    Object? instance,
+    String? instanceName,
+    FutureOr Function(T)? disposingFunction,
+    bool fromAllScopes = false,
+  });
+
   /// returns a Future that completes if all asynchronously created Singletons and any
   /// Singleton that had [signalsReady==true] are ready.
   /// This can be used inside a FutureBuilder to change the UI as soon as all initialization
@@ -649,11 +658,10 @@ abstract class GetIt {
   void signalReady(Object? instance);
 
   /// Returns the number of times a singleton has been accessed.
+  /// Only available in debug mode.
   int getAccessCount<T extends Object>({String? instanceName});
 
-  /// Clears all instances of a specific type, including named instances.
-  Future<void> clearAllInstances<T extends Object>();
-
-  /// Sets a default instance for a type, replacing the existing one if present.
-  void setDefault<T extends Object>(T instance, {String? instanceName});
+  /// Replaces an existing singleton instance with a new instance.
+  /// Throws if the instance is not found or is not a singleton.
+  void replaceSingletonInstance<T extends Object>(T newInstance, {String? instanceName});
 }

--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -174,7 +174,10 @@ class _ServiceFactory<T extends Object, P1, P2> {
 
   /// returns an instance depending on the type of the registration if [async==false]
   T getObject(dynamic param1, dynamic param2) {
-    if (_isDebugMode) _accessCount++;
+    assert(() {
+      _accessCount++;
+      return true;
+    }());
     assert(
       !(factoryType != _ServiceFactoryType.alwaysNew &&
           (param1 != null || param2 != null)),
@@ -258,7 +261,10 @@ class _ServiceFactory<T extends Object, P1, P2> {
   /// returns an async instance depending on the type of the registration if [async==true] or
   /// if [dependsOn.isNotEmpty].
   Future<R> getObjectAsync<R>(dynamic param1, dynamic param2) async {
-    if (_isDebugMode) _accessCount++;
+    assert(() {
+      _accessCount++;
+      return true;
+    }());
     assert(
       !(factoryType != _ServiceFactoryType.alwaysNew &&
           (param1 != null || param2 != null)),
@@ -2139,7 +2145,12 @@ class _GetItImplementation implements GetIt {
   /// Get the number of times a singleton is accessed by an [instance], a type [T] or an [instanceName]
   @override
   int getAccessCount<T extends Object>({String? instanceName}) {
-    assert(_isDebugMode, 'getAccessCount is only available in debug mode');
+    assert(() {
+      final _ = _findFactoryByNameAndType<T>(instanceName);
+      return true;
+    }(), 'getAccessCount is only available in debug mode');
+    
+    // This will only be executed in debug mode
     final factory = _findFactoryByNameAndType<T>(instanceName);
     return factory._accessCount;
   }

--- a/test/get_it_test.dart
+++ b/test/get_it_test.dart
@@ -1295,19 +1295,28 @@ void main() {
 
   test('Access count tracking (debug only)', () {
       final getIt = GetIt.instance;
-      if (getIt.isDebugMode) {
-        getIt.registerSingleton<TestClass>(TestClass());
+      getIt.registerSingleton<TestClass>(TestClass());
+
+      getIt<TestClass>();
+      getIt<TestClass>();
+      getIt<TestClass>();
+
+      expect(getIt.getAccessCount<TestClass>(), equals(3));
+    }
+  );
+
+  test('Reset count tracking (debug only)', () {
+      final getIt = GetIt.instance;
+      getIt.registerSingleton<TestClass>(TestClass());
 
         getIt<TestClass>();
         getIt<TestClass>();
         getIt<TestClass>();
+        
+        getIt.resetAccessCount<TestClass>();
 
-        expect(getIt.getAccessCount<TestClass>(), equals(3));
-      } else {
-        expect(() => getIt.getAccessCount<TestClass>(), throwsStateError);
-      }
-    },
-    skip: !assertionsEnabled(),
+        expect(getIt.getAccessCount<TestClass>(), equals(0));
+    }
   );
 
   test('Unregister from all scopes', () async {
@@ -1401,13 +1410,3 @@ class SingletonInjector {
 }
 
 class Injector {}
-
-// Helper function to check if assertions are enabled
-bool assertionsEnabled() {
-  var assertionsEnabled = false;
-  assert(() {
-    assertionsEnabled = true;
-    return true;
-  }());
-  return assertionsEnabled;
-}

--- a/test/get_it_test.dart
+++ b/test/get_it_test.dart
@@ -1292,6 +1292,54 @@ void main() {
       reason: "getIt.reset() did not dispose in reverse order",
     );
   });
+
+  test('Access count tracking', () {
+    final getIt = GetIt.instance;
+    getIt.registerSingleton<TestClass>(TestClass());
+
+    getIt<TestClass>();
+    getIt<TestClass>();
+    getIt<TestClass>();
+
+    expect(getIt.getAccessCount<TestClass>(), equals(3));
+  });
+
+  test('Clear all instances of a type', () async {
+    final getIt = GetIt.instance;
+    getIt.registerSingleton<TestClass>(TestClass());
+    getIt.registerSingleton<TestClass>(TestClass(), instanceName: 'named');
+
+    await getIt.clearAllInstances<TestClass>();
+
+    expect(getIt.isRegistered<TestClass>(), isFalse);
+    expect(getIt.isRegistered<TestClass>(instanceName: 'named'), isFalse);
+  });
+
+  test('Set default instance', () {
+    final getIt = GetIt.instance;
+    final defaultInstance = TestClass();
+    getIt.setDefault<TestClass>(defaultInstance);
+
+    expect(getIt<TestClass>(), equals(defaultInstance));
+
+    final newInstance = TestClass();
+    getIt.setDefault<TestClass>(newInstance);
+
+    expect(getIt<TestClass>(), equals(newInstance));
+  });
+
+  test('Set default instance with name', () {
+    final getIt = GetIt.instance;
+    final defaultInstance = TestClass();
+    getIt.setDefault<TestClass>(defaultInstance, instanceName: 'named');
+
+    expect(getIt<TestClass>(instanceName: 'named'), equals(defaultInstance));
+
+    final newInstance = TestClass();
+    getIt.setDefault<TestClass>(newInstance, instanceName: 'named');
+
+    expect(getIt<TestClass>(instanceName: 'named'), equals(newInstance));
+  });
 }
 
 class SingletonInjector {

--- a/test/get_it_test.dart
+++ b/test/get_it_test.dart
@@ -1293,16 +1293,19 @@ void main() {
     );
   });
 
-  test('Access count tracking', () {
-    final getIt = GetIt.instance;
-    getIt.registerSingleton<TestClass>(TestClass());
+  test('Access count tracking (debug only)', () {
+      final getIt = GetIt.instance;
+      getIt.registerSingleton<TestClass>(TestClass());
 
-    getIt<TestClass>();
-    getIt<TestClass>();
-    getIt<TestClass>();
+      getIt<TestClass>();
+      getIt<TestClass>();
+      getIt<TestClass>();
 
-    expect(getIt.getAccessCount<TestClass>(), equals(3));
-  });
+      // This will only work in debug mode
+      expect(getIt.getAccessCount<TestClass>(), equals(3));
+    },
+    skip: !assertionsEnabled(), // Skip this test in release mode
+  );
 
   test('Unregister from all scopes', () async {
     final getIt = GetIt.instance;
@@ -1336,7 +1339,8 @@ void main() {
     getIt.registerSingleton<TestClass>(initialInstance, instanceName: 'named');
 
     final newInstance = TestClass();
-    getIt.replaceSingletonInstance<TestClass>(newInstance, instanceName: 'named');
+    getIt.replaceSingletonInstance<TestClass>(newInstance,
+        instanceName: 'named');
 
     expect(getIt<TestClass>(instanceName: 'named'), equals(newInstance));
   });
@@ -1346,14 +1350,16 @@ void main() {
     getIt.registerFactory<TestClass>(() => TestClass());
 
     expect(
-      () => getIt.replaceSingletonInstance<TestClass>(TestClass()), throwsA(isA<StateError>()),
+      () => getIt.replaceSingletonInstance<TestClass>(TestClass()),
+      throwsA(isA<StateError>()),
     );
   });
 
   test('Cannot replace non-existent instance', () {
     final getIt = GetIt.instance;
     expect(
-      () => getIt.replaceSingletonInstance<TestClass>(TestClass()), throwsA(isA<StateError>()),
+      () => getIt.replaceSingletonInstance<TestClass>(TestClass()),
+      throwsA(isA<StateError>()),
     );
   });
 }
@@ -1365,3 +1371,13 @@ class SingletonInjector {
 }
 
 class Injector {}
+
+// Helper function to check if assertions are enabled
+bool assertionsEnabled() {
+  var assertionsEnabled = false;
+  assert(() {
+    assertionsEnabled = true;
+    return true;
+  }());
+  return assertionsEnabled;
+}


### PR DESCRIPTION
- **Access Count Tracking** : We can now track how many times a singleton has been accessed using the `getAccessCount` method.
- **Clear All Instances** : The `clearAllInstances` method allows clearing all instances of a specific type, including named instances.
- **Set Default Instance** : The `setDefault` method allows setting or replacing the default instance for a type, with an option to use a named instance.