### PR TITLE
Revise and improve cached factory handling with params

### DIFF
--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -1552,8 +1552,6 @@ class _GetItImplementation implements GetIt {
     FactoryFuncAsync<T>? factoryFuncAsync,
     FactoryFuncParamAsync<T, P1, P2>? factoryFuncParamAsync,
     T? instance,
-    P1? param1,
-    P2? param2,
     required String? instanceName,
     required bool isAsync,
     Iterable<Type>? dependsOn,

--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -171,7 +171,8 @@ class _ServiceFactory<T extends Object, P1, P2> {
   /// returns an instance depending on the type of the registration if [async==false]
   T getObject(dynamic param1, dynamic param2) {
     assert(
-      !(factoryType != _ServiceFactoryType.alwaysNew &&
+      !(![_ServiceFactoryType.alwaysNew, _ServiceFactoryType.cachedFactory]
+              .contains(factoryType) &&
           (param1 != null || param2 != null)),
       'You can only pass parameters to factories!',
     );
@@ -201,6 +202,8 @@ class _ServiceFactory<T extends Object, P1, P2> {
               param2 == lastParam2) {
             return weakReferenceInstance!.target!;
           } else {
+            lastParam1 = param1 as P1;
+            lastParam2 = param2 as P2;
             T newInstance;
             if (creationFunctionParam != null) {
               newInstance = creationFunctionParam!(param1 as P1, param2 as P2);
@@ -1546,6 +1549,8 @@ class _GetItImplementation implements GetIt {
     FactoryFuncAsync<T>? factoryFuncAsync,
     FactoryFuncParamAsync<T, P1, P2>? factoryFuncParamAsync,
     T? instance,
+    P1? param1,
+    P2? param2,
     required String? instanceName,
     required bool isAsync,
     Iterable<Type>? dependsOn,

--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -202,8 +202,8 @@ class _ServiceFactory<T extends Object, P1, P2> {
               param2 == lastParam2) {
             return weakReferenceInstance!.target!;
           } else {
-            lastParam1 = param1 as P1;
-            lastParam2 = param2 as P2;
+            lastParam1 = param1 as P1?;
+            lastParam2 = param2 as P2?;
             T newInstance;
             if (creationFunctionParam != null) {
               newInstance = creationFunctionParam!(param1 as P1, param2 as P2);

--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -257,7 +257,8 @@ class _ServiceFactory<T extends Object, P1, P2> {
   /// if [dependsOn.isNotEmpty].
   Future<R> getObjectAsync<R>(dynamic param1, dynamic param2) async {
     assert(
-      !(factoryType != _ServiceFactoryType.alwaysNew &&
+      !(![_ServiceFactoryType.alwaysNew, _ServiceFactoryType.cachedFactory]
+              .contains(factoryType) &&
           (param1 != null || param2 != null)),
       'You can only pass parameters to factories!',
     );
@@ -294,6 +295,8 @@ class _ServiceFactory<T extends Object, P1, P2> {
             return Future<R>.value(weakReferenceInstance!.target! as R);
           } else {
             if (creationFunctionParam != null) {
+              lastParam1 = param1 as P1?;
+              lastParam2 = param2 as P2?;
               return asyncCreationFunctionParam!(param1 as P1, param2 as P2)
                   .then((value) {
                 weakReferenceInstance = WeakReference(value);

--- a/test/get_it_test.dart
+++ b/test/get_it_test.dart
@@ -39,11 +39,17 @@ class TestClassDisposable extends TestBaseClass with Disposable {
 
 class TestClass2 {}
 
-class TestClassParam {
+class TestClassParam extends TestBaseClass {
   final String? param1;
   final int? param2;
 
-  TestClassParam({this.param1, this.param2});
+  TestClassParam({this.param1, this.param2}) {
+    constructorCounter++;
+  }
+
+  void dispose() {
+    disposeCounter++;
+  }
 }
 
 class TestClassDisposableWithDependency with Disposable {
@@ -214,6 +220,80 @@ void main() {
     expect(constructorCounter, 2);
 
     GetIt.I.reset();
+  });
+
+  test('register cached factory', () {
+    final getIt = GetIt.instance;
+    constructorCounter = 0;
+    getIt.registerCachedFactory<TestBaseClass>(() => TestClass());
+    final TestBaseClass instance1 = getIt<TestBaseClass>();
+    expect(instance1 is TestClass, true);
+    final instance2 = getIt.get<TestBaseClass>();
+    expect(getIt.isRegistered<TestBaseClass>(), true);
+    expect(instance1, instance2);
+    expect(constructorCounter, 1);
+  });
+
+  test('register cached factory with one param ', () {
+    final getIt = GetIt.instance;
+    constructorCounter = 0;
+    getIt.registerCachedFactoryParam<TestClassParam, String, void>(
+      (s, _) => TestClassParam(param1: s),
+    );
+    final instance1 = getIt<TestClassParam>(param1: 'abc');
+    final instance2 = getIt<TestClassParam>(param1: 'abc');
+    expect(instance1 is TestClassParam, true);
+    expect(instance1.param1, 'abc');
+    expect(instance1, instance2);
+    expect(constructorCounter, 1);
+  });
+
+  test('register cached factory with different params', () {
+    final getIt = GetIt.instance;
+    constructorCounter = 0;
+    getIt.registerCachedFactoryParam<TestClassParam, String, void>(
+      (s, _) => TestClassParam(param1: s),
+    );
+    final instance1 = getIt<TestClassParam>(param1: 'abc');
+    final instance2 = getIt<TestClassParam>(param1: '123');
+    expect(instance1 is TestClassParam, true);
+    expect(instance1.param1, 'abc');
+    expect(instance2.param1, '123');
+    expect(instance2 is TestClassParam, true);
+    expect(instance1, isNot(instance2));
+    expect(constructorCounter, 2);
+  });
+
+  test('register cached factory with two equal params', () {
+    final getIt = GetIt.instance;
+    constructorCounter = 0;
+    getIt.registerCachedFactoryParam<TestClassParam, String, int>(
+      (f,s) => TestClassParam(param1: f,param2:s),
+    );
+    final instance1 = getIt<TestClassParam>(param1: 'abc', param2: 1);
+    final instance2 = getIt<TestClassParam>(param1: 'abc', param2: 1);
+    expect(instance1 is TestClassParam, true);
+    expect(instance1.param1, 'abc');
+    expect(instance1, instance2);
+    expect(constructorCounter, 1);
+  });
+
+  test('register cached factory with one different param out of two', () {
+    final getIt = GetIt.instance;
+    constructorCounter = 0;
+    getIt.registerCachedFactoryParam<TestClassParam, String, int>(
+      (f,s) => TestClassParam(param1: f,param2: s),
+    );
+    final instance1 = getIt<TestClassParam>(param1: 'abc', param2: 1);
+    final instance2 = getIt<TestClassParam>(param1: 'abc', param2: 2);
+    expect(instance1 is TestClassParam, true);
+    expect(instance1.param1, 'abc');
+    expect(instance1.param2, 1);
+    expect(instance2.param1, 'abc');
+    expect(instance2.param2, 2);
+    expect(instance2 is TestClassParam, true);
+    expect(instance1, isNot(instance2));
+    expect(constructorCounter, 2);
   });
 
   test('register constant', () {

--- a/test/get_it_test.dart
+++ b/test/get_it_test.dart
@@ -46,10 +46,6 @@ class TestClassParam extends TestBaseClass {
   TestClassParam({this.param1, this.param2}) {
     constructorCounter++;
   }
-
-  void dispose() {
-    disposeCounter++;
-  }
 }
 
 class TestClassDisposableWithDependency with Disposable {
@@ -268,7 +264,7 @@ void main() {
     final getIt = GetIt.instance;
     constructorCounter = 0;
     getIt.registerCachedFactoryParam<TestClassParam, String, int>(
-      (f,s) => TestClassParam(param1: f,param2:s),
+      (f, s) => TestClassParam(param1: f, param2: s),
     );
     final instance1 = getIt<TestClassParam>(param1: 'abc', param2: 1);
     final instance2 = getIt<TestClassParam>(param1: 'abc', param2: 1);
@@ -282,7 +278,7 @@ void main() {
     final getIt = GetIt.instance;
     constructorCounter = 0;
     getIt.registerCachedFactoryParam<TestClassParam, String, int>(
-      (f,s) => TestClassParam(param1: f,param2: s),
+      (f, s) => TestClassParam(param1: f, param2: s),
     );
     final instance1 = getIt<TestClassParam>(param1: 'abc', param2: 1);
     final instance2 = getIt<TestClassParam>(param1: 'abc', param2: 2);


### PR DESCRIPTION
This Pr references issue #382 where an assertion  on the getObject method (and its async equivalent) blocks cached factories from having parameters passed.
The fix is adjusting the assertion to include the "cachedFactory" as a type.
While fixing this issue I also noticed that the lastParameters were not being saved in the cached factory section, which resulted in the cached factory functions being broken since this check always failed:
```dart
if (weakReferenceInstance?.target != null &&
              param1 == lastParam1 &&
              param2 == lastParam2)
```
Saving the lastParams when creating new instances fixes this.

Appropriate tests have been writen for the cached factory which were entirely missing earlier.

