### PR TITLE
Getting rid of static analysis warning on pub.dev

### DIFF
--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -361,8 +361,6 @@ class _ServiceFactory<T extends Object, P1, P2> {
             });
             return pendingResult! as Future<R>;
           }
-        default:
-          throw StateError('Impossible factoryType');
       }
     } catch (e, s) {
       _debugOutput('Error while creating $T}');


### PR DESCRIPTION
There was a default case in a switch statement, that could not be reached since the possible values of the switch statement are completely coververed.

This led to a reduces Pub Score on pub.dev