### PR TITLE
Allow querying registrations by passing type parameter to isRegistered

### DIFF
--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -450,9 +450,13 @@ abstract class GetIt {
     bool useWeakReference = false,
   });
 
-  /// Tests if an [instance] of an object or aType [T] or a name [instanceName]
+  /// Tests if an [instance] of an object or a Type ([T] or [type]) or a name [instanceName]
   /// is registered inside GetIt
-  bool isRegistered<T extends Object>({Object? instance, String? instanceName});
+  bool isRegistered<T extends Object>({
+    Object? instance,
+    String? instanceName,
+    Type? type,
+  });
 
   /// In some cases it can be necessary to change the name of a registered instance
   /// This avoids to unregister and reregister the instance which might cause trouble

--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -1103,11 +1103,14 @@ class _GetItImplementation implements GetIt {
   bool isRegistered<T extends Object>({
     Object? instance,
     String? instanceName,
+    Type? type,
   }) {
     if (instance != null) {
       return _findFirstFactoryByInstanceOrNull(instance) != null;
     } else {
-      return _findFirstFactoryByNameAndTypeOrNull<T>(instanceName) != null;
+      return _findFirstFactoryByNameAndTypeOrNull<T>(instanceName,
+              type: type) !=
+          null;
     }
   }
 

--- a/test/get_it_test.dart
+++ b/test/get_it_test.dart
@@ -1368,6 +1368,23 @@ void main() {
       reason: "getIt.reset() did not dispose in reverse order",
     );
   });
+
+  test('isRegistered queryable by type param', () {
+    final getIt = GetIt.instance;
+
+    getIt.registerSingleton<TestClass2>(TestClass2());
+
+    final bool byGenerics = getIt.isRegistered<TestClass>();
+    final bool byParam = getIt.isRegistered(type: TestClass);
+
+    final bool byGenerics2 = getIt.isRegistered<TestClass2>();
+    final bool byParam2 = getIt.isRegistered(type: TestClass2);
+
+    expect(byParam, byGenerics);
+    expect(byParam, false);
+    expect(byParam2, byGenerics2);
+    expect(byParam2, true);
+  });
 }
 
 class SingletonInjector {


### PR DESCRIPTION
If entities can be retrieved via type parameter, it makes sense to be able to check for registered entities via the same mechanism.